### PR TITLE
Remove unneeded dependencies from setup.cfg

### DIFF
--- a/nvidia.ps1
+++ b/nvidia.ps1
@@ -109,6 +109,10 @@ if($archiverProgram = "$env:programfiles\7-zip\7z.exe") {
 }
 
 
+# Remove unneeded dependencies from setup.cfg
+(Get-Content "$extractDir\$version\setup.cfg") | Where-Object {$_ -notmatch 'EulaHtmlFile|FunctionalConsentFile|PrivacyPolicyFile'} | Set-Content "$extractDir\$version\setup.cfg" -Force
+
+
 # Installing drivers
 Write-Host "Installing Nvidia drivers now..."
 $install_args = "-s -noreboot -noeula"


### PR DESCRIPTION
The script fails to install the driver. This fixes it. More info [here](https://forums.geforce.com/default/topic/1057783/geforce-drivers/397-93-setup-exe-says-quot-the-system-cannot-find-the-path-specified-quot-/).