### PR TITLE
Remove double word in comment.

### DIFF
--- a/nvidia.ps1
+++ b/nvidia.ps1
@@ -12,7 +12,7 @@ param (
 
 
 $scheduleTask = $false  # Creates a Scheduled Task to run to check for driver updates
-$scheduleDay = "Sunday" # When should the scheduled task should run (Default = Sunday)
+$scheduleDay = "Sunday" # When should the scheduled task run (Default = Sunday)
 $scheduleTime = "12pm"  # The time the scheduled task should run (Default = 12pm)
 
 


### PR DESCRIPTION
Hi,

There's an extra word in a comment in the code. I've fixed the extra word in this pull-request.

Greetings,

HonkingGoose.