### PR TITLE
Use diffrent architecture detection methode

### DIFF
--- a/nvidia.ps1
+++ b/nvidia.ps1
@@ -83,7 +83,7 @@ if ([Environment]::OSVersion.Version -ge (new-object 'Version' 9, 1)) {
 
 
 # Checking Windows bitness
-if ((Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture -eq "64-bit") {
+if ([Environment]::Is64BitOperatingSystem) {
     $windowsArchitecture = "64bit"
 } else {
     $windowsArchitecture = "32bit"


### PR DESCRIPTION
Hello,

I have the same issue describe here:
https://stackoverflow.com/questions/44243960/powershell-output-english-only-on-non-english-os

Using this different architecture detection method works like a charm.

Thanks