### PR TITLE
feat: Set Windows Driver Type as Standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,19 @@ schtasks /run /tn "Nvidia-Updater"
 
 7-Zip or WinRar are needed to extract the drivers.
 They need to be installed in their default locations (`programfiles\7-zip\7z.exe` and `programfiles\WinRAR\WinRAR.exe`)
+
+## FAQ
+
+Q. How is checked the latest driver version from Nvidia website ?
+
+> We use the NVIDIA [Advanced Driver Search](https://www.nvidia.com/Download/Find.aspx).
+>
+> Example:
+> ```https://www.nvidia.com/Download/processFind.aspx?psid=101&pfid=845&osid=57&lid=1&whql=1&ctk=0&dtcid=0```
+>
+> * **psid**: Product Series ID (_GeForce 10 Series_: 101)
+> * **pfid**: Product ID (e.g. _GeForce GTX 1080 Ti_: 845)
+> * **osid**: Operating System ID (e.g. _Windows 10 64-bit_: 57)
+> * **lid**: Language ID (e.g. _English (US)_: 1)
+> * **whql**: Driver channel (_Certified_: 0, Beta: 1)
+> * **dtcid**: Windows Driver Type (_Standard_: 0, DHC: 1)

--- a/README.md
+++ b/README.md
@@ -57,3 +57,12 @@ Q. How do we check for the latest driver version from Nvidia website ?
 > * **lid**: Language ID (e.g. _English (US)_: 1)
 > * **whql**: Driver channel (_Certified_: 0, Beta: 1)
 > * **dtcid**: Windows Driver Type (_Standard_: 0, DCH: 1)
+
+Q. Why DCH drivers are not supported ?
+
+> While the DCH driver is exactly the same as the Standard one, the way DCH drivers are packaged differs.
+>
+> * Standard: To upgrade, you have either to download/install manually new drivers, or let GeForce Experience doing it.
+> * DCH: Windows Update will download and install the NVIDIA DCH Display Driver.
+>
+> For more informations, you can read the [NVIDIA Display Drivers for Windows 10 FAQ](https://nvidia.custhelp.com/app/answers/detail/a_id/4777/~/nvidia-dch%2Fstandard-display-drivers-for-windows-10-faq)

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Q. How is checked the latest driver version from Nvidia website ?
 > * **osid**: Operating System ID (e.g. _Windows 10 64-bit_: 57)
 > * **lid**: Language ID (e.g. _English (US)_: 1)
 > * **whql**: Driver channel (_Certified_: 0, Beta: 1)
-> * **dtcid**: Windows Driver Type (_Standard_: 0, DHC: 1)
+> * **dtcid**: Windows Driver Type (_Standard_: 0, DCH: 1)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ They need to be installed in their default locations (`programfiles\7-zip\7z.exe
 
 ## FAQ
 
-Q. How is checked the latest driver version from Nvidia website ?
+Q. How do we check for the latest driver version from Nvidia website ?
 
 > We use the NVIDIA [Advanced Driver Search](https://www.nvidia.com/Download/Find.aspx).
 >

--- a/nvidia.ps1
+++ b/nvidia.ps1
@@ -49,6 +49,13 @@ else {
 
 # Checking currently installed driver version
 Write-Host "Attempting to detect currently installed driver version..."
+if (Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\nvlddmkm -Name 'DCHUVen' -ErrorAction Ignore) {
+    Write-Host "DCH driver are not yet supported."
+    Write-Host "Press any key to exit..."
+    $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+    exit
+}
+
 try {
     $ins_version = (Get-WmiObject Win32_PnPSignedDriver | Where-Object { $_.devicename -like "*nvidia*" -and $_.devicename -notlike "*audio*" -and $_.devicename -notlike "*USB*" -and $_.devicename -notlike "*SHIELD*" }).DriverVersion.SubString(7).Remove(1, 1).Insert(3, ".")
 }

--- a/nvidia.ps1
+++ b/nvidia.ps1
@@ -62,7 +62,7 @@ Write-Host "Installed version `t$ins_version"
 
 
 # Checking latest driver version from Nvidia website
-$link = Invoke-WebRequest -Uri 'https://www.nvidia.com/Download/processFind.aspx?psid=101&pfid=816&osid=57&lid=1&whql=1&lang=en-us&ctk=0' -Method GET -UseBasicParsing
+$link = Invoke-WebRequest -Uri 'https://www.nvidia.com/Download/processFind.aspx?psid=101&pfid=816&osid=57&lid=1&whql=1&lang=en-us&ctk=0&dtcid=0' -Method GET -UseBasicParsing
 $link -match '<td class="gridItem">([^<]+?)</td>' | Out-Null
 $version = $matches[1]
 Write-Host "Latest version `t`t$version"

--- a/nvidia.ps1
+++ b/nvidia.ps1
@@ -50,7 +50,7 @@ else {
 # Checking currently installed driver version
 Write-Host "Attempting to detect currently installed driver version..."
 if (Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\nvlddmkm -Name 'DCHUVen' -ErrorAction Ignore) {
-    Write-Host "DCH driver are not yet supported."
+    Write-Host -ForegroundColor Yellow "DCH driver are not supported. Windows Update will download and install the NVIDIA DCH Display Driver."
     Write-Host "Press any key to exit..."
     $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
     exit
@@ -60,7 +60,7 @@ try {
     $ins_version = (Get-WmiObject Win32_PnPSignedDriver | Where-Object { $_.devicename -like "*nvidia*" -and $_.devicename -notlike "*audio*" -and $_.devicename -notlike "*USB*" -and $_.devicename -notlike "*SHIELD*" }).DriverVersion.SubString(7).Remove(1, 1).Insert(3, ".")
 }
 catch {
-    Write-Host "Unable to detect a compatible Nvidia device."
+    Write-Host -ForegroundColor Yellow "Unable to detect a compatible Nvidia device."
     Write-Host "Press any key to exit..."
     $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
     exit
@@ -169,7 +169,7 @@ Remove-Item $nvidiaTempFolder -Recurse -Force
 
 
 # Driver installed, requesting a reboot
-Write-Host "Driver installed. You may need to reboot to finish installation."
+Write-Host -ForegroundColor Green "Driver installed. You may need to reboot to finish installation."
 Write-Host "Would you like to reboot now?"
 $Readhost = Read-Host "(Y/N) Default is no"
 Switch ($ReadHost) {


### PR DESCRIPTION
There is a new option in the NVIDIA driver searcher named as Windows Driver Type. (https://www.nvidia.com/Download/Find.aspx?lang=en-us#)

"Standard" packages are those that do not require the DCH driver components.
"DCH" (Declarative, Componentized, Hardware Support Apps) refers to new packages preinstalled by OEMS implementing the Microsoft Universal Driver paradigm.
DCH drivers cannot be installed over a standard system, and Standard drivers cannot be installed over a DCH system.

dtcid=0 mean Standard
dtcid=1 means DCH