### PR TITLE
Cleanup in archive detection and variables.

### DIFF
--- a/nvidia.ps1
+++ b/nvidia.ps1
@@ -17,52 +17,48 @@ $scheduleTime = "12pm"  # The time the scheduled task should run (Default = 12pm
 
 
 # Checking if 7zip or WinRAR are installed
-#Check 7zip install path on registry
-if((Test-path HKLM:\SOFTWARE\7-Zip\) -eq $true){
-    $7zpath = Get-ItemProperty -path  HKLM:\SOFTWARE\7-Zip\ -Name Path  
-    $7zipinstalled = $true 
-   }
-   else{
-       $7zipinstalled = $false 
-   }
-   if($7zipinstalled -eq $true){
-   $7zpath = $7zpath.Path
-   $7zpathexe = $7zpath + "7z.exe"
-   if((Test-Path $7zpathexe) -eq $true){
-       $archiverProgram = $7zpath + "7z.exe"
-       }
-   }
-   elseif($7zipinstalled -eq $false){
-       if((Test-path HKLM:\SOFTWARE\WinRAR) -eq $true){
-           $winrarpath = Get-ItemProperty -Path HKLM:\SOFTWARE\WinRAR -Name exe64 
-           $winrarpath = $winrarpath.exe64
-       if((Test-Path $winrarpath) -eq $true){
-               $archiverProgram = $winrarpath
-           }
-       }
-   }
-   else {
-       Write-Host "Sorry, but it looks like you don't have a supported archiver."
-       Write-Host ""
-       while ($choice -notmatch "[y|n]") {
-           $choice = read-host "Would you like to install 7-Zip now? (Y/N)"
-       }
-       if ($choice -eq "y") {
-           # Download and silently install 7-zip if the user presses y
-           $7zip = "https://www.7-zip.org/a/7z1900-x64.exe"
-           $output = "$PSScriptRoot\7Zip.exe"
-           (New-Object System.Net.WebClient).DownloadFile($7zip, $output)
+# Check 7zip install path on registry
+$7zipinstalled = $false 
+if ((Test-path HKLM:\SOFTWARE\7-Zip\) -eq $true) {
+    $7zpath = Get-ItemProperty -path  HKLM:\SOFTWARE\7-Zip\ -Name Path
+    $7zpath = $7zpath.Path
+    $7zpathexe = $7zpath + "7z.exe"
+    if ((Test-Path $7zpathexe) -eq $true) {
+        $archiverProgram = $7zpathexe
+        $7zipinstalled = $true 
+    }    
+}
+elseif ($7zipinstalled -eq $false) {
+    if ((Test-path HKLM:\SOFTWARE\WinRAR) -eq $true) {
+        $winrarpath = Get-ItemProperty -Path HKLM:\SOFTWARE\WinRAR -Name exe64 
+        $winrarpath = $winrarpath.exe64
+        if ((Test-Path $winrarpath) -eq $true) {
+            $archiverProgram = $winrarpath
+        }
+    }
+}
+else {
+    Write-Host "Sorry, but it looks like you don't have a supported archiver."
+    Write-Host ""
+    while ($choice -notmatch "[y|n]") {
+        $choice = read-host "Would you like to install 7-Zip now? (Y/N)"
+    }
+    if ($choice -eq "y") {
+        # Download and silently install 7-zip if the user presses y
+        $7zip = "https://www.7-zip.org/a/7z1900-x64.exe"
+        $output = "$PSScriptRoot\7Zip.exe"
+        (New-Object System.Net.WebClient).DownloadFile($7zip, $output)
        
-           Start-Process "7Zip.exe" -Wait -ArgumentList "/S"
-           # Delete the installer once it completes
-           Remove-Item "$PSScriptRoot\7Zip.exe"
-       }
-       else {
-           Write-Host "Press any key to exit..."
-           $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
-           exit
-       }
-   }
+        Start-Process "7Zip.exe" -Wait -ArgumentList "/S"
+        # Delete the installer once it completes
+        Remove-Item "$PSScriptRoot\7Zip.exe"
+    }
+    else {
+        Write-Host "Press any key to exit..."
+        $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+        exit
+    }
+}
    
 
 
@@ -148,11 +144,18 @@ else {
 $extractFolder = "$nvidiaTempFolder\$version"
 $filesToExtract = "Display.Driver HDAudio NVI2 PhysX EULA.txt ListDevices.txt setup.cfg setup.exe"
 Write-Host "Download finished, extracting the files now..."
-if ($archiverProgram -eq "$7zpath\7z.exe") {
+
+if ($7zipinstalled) {
     Start-Process -FilePath $archiverProgram -NoNewWindow -ArgumentList "x -bso0 -bsp1 -bse1 -aoa $dlFile $filesToExtract -o""$extractFolder""" -wait
 }
 elseif ($archiverProgram -eq $winrarpath) {
     Start-Process -FilePath $archiverProgram -NoNewWindow -ArgumentList 'x $dlFile $extractFolder -IBCK $filesToExtract' -wait
+}
+else {
+    Write-Host "Something went wrong. No archive program detected. This should not happen."
+    Write-Host "Press any key to exit..."
+    $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+    exit
 }
 
 


### PR DESCRIPTION
We already had a `$7zipinstalled` variable, so why not use it. Small stuff like that.
I had a bug where `$archiverProgram -eq "$7zpath\7z.exe"` would not work, as the parth already had a `\`

If someone could test run this, it would be great.